### PR TITLE
fixed aimbot target logic, don't look for the dead

### DIFF
--- a/modCode.bas
+++ b/modCode.bas
@@ -6259,7 +6259,7 @@ Public Function SendAimbot(target As String, idConnection As Integer, runeB1 As 
         Else
           lSquare = LCase(GetNameFromID(idConnection, tmpID))
         End If
-        If (Len(lTarget) <> 0 And lSquare = lTarget) Or (Len(lTarget) = 0 And RedSquareID <> 0 And RedSquareID = tmpID) Or (RedSquareID = 0 And Len(lTarget) = 0 And Len(lLastTargetName) <> 0 And lLastTargetName = lSquare) Then
+        If (Len(lTarget) <> 0 And lSquare = lTarget) Or (Len(lTarget) = 0 And RedSquareID <> 0 And RedSquareID = tmpID) Or (((RedSquareID = 0 Or Not HPOfID(idConnection).Exists(RedSquareID)) Or GetHPFromID(idConnection, CDbl(RedSquareID)) = 0) And Len(lTarget) = 0 And Len(lLastTargetName) <> 0 And lLastTargetName = lSquare) Then
         '0D 00 84 FF FF 40 00 00 40 0C 00 CB DD 01 40
           If SpecialSource = True Then
                sCheat = "83 FF FF 00 00 00 " & GoodHex(runeB1) & " " & GoodHex(runeB2) & " " & _


### PR DESCRIPTION
new logic:
1: if target name is specified, shoot target name.
2: if no target name is specified, but a target id specified (by battle), and target id is not dead, shoot target id
3: if no target name is specified, and a target id is specified (by battle), but the target id is already dead, then shoot first found target with the same name as the target id.

this is exactly what i tried to do last time i updated the aimbot logic, but i made a small bug: it would still look for the dead target, instead of shooting an other target with the same name as the target id.

note that it may occasionally be affected by bug  blackdtools/Blackd-Proxy-CLASSIC#12 , at least on tibia 7.6
