### PR TITLE
Like regex for event

### DIFF
--- a/frmEvents.frm
+++ b/frmEvents.frm
@@ -909,6 +909,7 @@ Private Sub Form_Load()
 cmbEventType.Clear
 cmbEventType.AddItem "0 - MSG THAT CONTAINS..."
 cmbEventType.AddItem "1 - EXACT MESSAGE"
+cmbEventType.AddItem "2 - Like Regex.."
 cmbEventType.Text = "0 - MSG THAT CONTAINS..."
 ReloadFiles
   With lstVar

--- a/modEvents.bas
+++ b/modEvents.bas
@@ -163,6 +163,23 @@ Public Sub ProcessEventMsg(idConnection As Integer, thetype As Byte)
           End If
         End If
       End If
+    ElseIf evType = 2 Then 'Like regex
+      If Mid(CustomEvents(idConnection).ev(i).flags, lotype, 1) = 1 Then
+        If ((CheatsPaused(idConnection) = False) Or (Mid$(CustomEvents(idConnection).ev(i).flags, 19, 1) = "1")) Then
+          partR = LCase(parseVars(idConnection, CustomEvents(idConnection).ev(i).trigger))
+          If partL Like partR Then 'triggered
+            executeThis = parseVars(idConnection, CustomEvents(idConnection).ev(i).action)
+            strTmp = Right$(CustomEvents(idConnection).ev(i).flags, Len(CustomEvents(idConnection).ev(i).flags) - 20)
+            mustdelay = CLng(strTmp)
+            If mustdelay = 0 Then
+              intRes = ExecuteInTibia(executeThis, idConnection, False)
+            Else
+              mustdelay = mustdelay + GetTickCount()
+              AddSchedule idConnection, executeThis, mustdelay
+            End If
+          End If
+        End If
+      End If
     End If
 
   Next i


### PR DESCRIPTION
currently there's no way to capture "every message".
i suggest adding a new event type 2, "Like regex"; 
with this regex, i can simply capture every message with the \* character

`Like` is also much more versatile than the other events, it can do  "MSG THAT CONTAINS" and "EXACT MESSAGE",  and many other things ^^
