### PR TITLE
add $urlencode:str$ (merge conflict fixed)

### DIFF
--- a/frmEvents.frm
+++ b/frmEvents.frm
@@ -945,6 +945,7 @@ ReloadFiles
     .AddItem "$hex-equiped-ammount:01$"
     .AddItem "$num-equiped-ammount:01$"
     .AddItem "$hex-equiped-ammount-special:01$"
+    .AddItem "$urlencode:are you there?$"
     .AddItem "$hex-tibiastr:hello$"
     .AddItem "$hex-lastattackedid$"
     .AddItem "$nameofhex-id:AB CD EF 00$"

--- a/modCode.bas
+++ b/modCode.bas
@@ -1102,6 +1102,31 @@ Public Function Hexarize(strinput As String) As String
   Hexarize = res
 End Function
 
+' url encodes a string
+'warning: unicode is untested
+'creds: http://www.vbforums.com/showthread.php?334645-Winsock-Making-HTTP-POST-GET-Requests
+Function URLEncode(ByVal str As String) As String
+        Dim intLen As Integer
+        Dim X As Integer
+        Dim curChar As Long
+                Dim newStr As String
+                intLen = Len(str)
+        newStr = ""
+                        For X = 1 To intLen
+            curChar = Asc(Mid$(str, X, 1))
+            
+            If (curChar < 48 Or curChar > 57) And _
+                (curChar < 65 Or curChar > 90) And _
+                (curChar < 97 Or curChar > 122) Then
+                                newStr = newStr & "%" & Hex(curChar)
+            Else
+                newStr = newStr & Chr(curChar)
+            End If
+        Next X
+        
+        URLEncode = newStr
+End Function
+
 Public Function Hexarize2(strinput As String) As String
   Dim strByte As String
   Dim res As String
@@ -7496,6 +7521,8 @@ While pos <= lastp
           theTranslation = IDofName(idConnection, Right$(varn, (Len(varn) - 13)), 0)
         ElseIf (Left$(varn, 13) = "nameofhex-id:") Then
           theTranslation = NameOfHexID(idConnection, Right$(varn, (Len(varn) - 13)))
+        ElseIf (Left$(varn, 10) = "urlencode:") Then
+          theTranslation = URLEncode(Right$(varn, (Len(varn) - 10)))
         ElseIf (Left$(varn, 13) = "hex-tibiastr:") Then
           theTranslation = Hexarize2(Right$(varn, (Len(varn) - 13)))
         ElseIf (Left$(varn, 8) = "httpget:") Then


### PR DESCRIPTION
here is a new $urlencode:str$ pull request, i fixed the git merge conflict :+1: 

this function complement $httpget:blabla$ , making it much more useful, for instance, you need to urlencode spaces for $geturl:www.website.com/autoResponder.php?name=GM Dicktwad&message=what are you doing?$    ,   so it becomes 
$geturl:www.website.com/autoResponder.php?name=GM%20Dicktwad&message=what%20are%20you%20doing%3F$
