### PR TITLE
 (for high exp ots) ignore and continue on errors in UpdateExpVars

### DIFF
--- a/modCode.bas
+++ b/modCode.bas
@@ -7206,7 +7206,7 @@ Public Sub UpdateExpVars(idConnection As Integer)
   Dim sRes As String
   Dim dblSol As Double
   Dim dblSol2 As Double
-  On Error GoTo goterr
+  On Error Resume Next
   sRes = ""
   var_expleft(idConnection) = "?"
   var_nextlevel(idConnection) = "?"


### PR DESCRIPTION
in high exp ots, "exp to next level" can overflow VB's Double / Long's,
thus "On Error GoTo goterr" will make everything "? exp to level ? - ? exp/h",
but if we use "On Error Resume Next" here, it will say "0 exp to level XXXX. exp/h: XXXXX", 
we can still calculate exp/h for a lot of levels, also in several OTs, your level is displayed as 0 and your exp displays your level after level 32767 because tibia client use a signed int16_t which can only hold up to level 32766 , while experience is an uint32_t which can hold up to 4294967295, so in this case, exp/h will now contain the level/h instead (instead of the current behaviour, everything is ?)
