### PR TITLE
animate number of seconds left on magic wall / wild growth

### DIFF
--- a/frmHardcoreCheats.frm
+++ b/frmHardcoreCheats.frm
@@ -1083,6 +1083,69 @@ Private Sub timerAutoUpdater_Timer()
   End If
 End Sub
 
+
+
+Private Sub CountdownXYZ()
+'
+If (Me.chkColorEffects <> 1) Then
+Exit Sub
+End If
+
+Dim i As Integer
+Dim ii As Integer
+Dim SecondsLeft As Long
+Dim CurrTicks As Long
+CurrTicks = GetTickCount()
+
+  For i = 1 To HighestConnectionID
+    For ii = 1 To MAXCLIENTS
+      If (XYZCountdowns(i, ii).s = 0) Then
+        'this 1 has expired.
+      Else
+      
+        SecondsLeft = XYZCountdowns(i, ii).s - (GetTickCount() / 1000) ' s contains expiry timestamp
+        If (SecondsLeft < 0) Then
+        XYZCountdowns(i, ii).s = 0 '0 means expired.
+          'XYZCountdowns(i).Remove (ii)
+        Else
+'        Debug.Print XYZCountdowns(i, ii).X
+'        Debug.Print XYZCountdowns(i, ii).y
+'        Debug.Print XYZCountdowns(i, ii).z
+'        Debug.Print XYZCountdowns(i, ii).s
+'         Debug.Print SecondsLeft
+'exiva < 84 7F 04 D2 01 07 66 05 00 31 30 30 30 30
+'        ^t XX XX YY YY ZZ CO TibiaStr
+'         modCode.sendString i, "84 7F 04 D2 01 07 66 05 00 31 30 30 30 30", False, True
+         modCode.sendString i, "84 " & FiveChrLon(XYZCountdowns(i, ii).X) & " " & FiveChrLon(XYZCountdowns(i, ii).y) & " " & GoodHex(CByte(XYZCountdowns(i, ii).z)) & " 66 " & Hexarize2(CStr(SecondsLeft)), False, True
+         End If
+      End If
+    Next
+  Next
+
+End Sub
+
+Public Function AddXYZCounter(idConnection As Integer, X As Long, y As Long, z As Long, Seconds As Long) As Boolean
+Dim Timestamp As Long
+Dim i As Long
+Dim pos As TypeMatrixPosition
+Dim res As Boolean
+  pos.X = X
+  pos.y = y
+  pos.z = z
+  Timestamp = (GetTickCount() / 1000) + Seconds
+  pos.s = Timestamp
+  res = False
+  For i = 1 To MAXCLIENTS
+  If (XYZCountdowns(idConnection, i).s = 0) Then
+    res = True
+    XYZCountdowns(idConnection, i) = pos
+    Exit For
+    End If
+  Next
+  AddXYZCounter = res ' if false, means that we are already counting the max number of walls :/ should fix limit
+End Function
+
+
 Private Sub timerLight_Timer()
   Dim i As Integer
   'Dim cPacket() As Byte
@@ -1106,6 +1169,7 @@ Private Sub timerLight_Timer()
   For i = 1 To HighestConnectionID
       errorD = i
   If (GameConnected(i) = True) And (sentWelcome(i) = True) And (GotPacketWarning(i) = False) Then
+  CountdownXYZ
     If ReconnectionStage(i) = 3 Then
       If frmBackpacks.totalbpsOpen(i) < CLng(txtRelogBackpacks.Text) Then
         aRes = openBP(i)

--- a/frmMain.frm
+++ b/frmMain.frm
@@ -3497,6 +3497,7 @@ ReDim DoingNewLootMAXGTC(1 To MAXCLIENTS)
   ReDim lastAttackedIDstatus(1 To MAXCLIENTS)
   ReDim executingCavebot(1 To MAXCLIENTS)
   ReDim lastPing(1 To MAXCLIENTS)
+  ReDim XYZCountdowns(1 To MAXCLIENTS, 1 To MAXCLIENTS) 'TODO: currently, we can only keep count of MAXCLIENTS walls per character. fix it so we can keep count of unlimited number of walls per character..
   ReDim doingTrade(1 To MAXCLIENTS)
   ReDim doingTrade2(1 To MAXCLIENTS)
   ReDim GotKillOrderTargetID(1 To MAXCLIENTS)

--- a/modMap.bas
+++ b/modMap.bas
@@ -246,6 +246,7 @@ Public GotPacketWarning() As Boolean ' for safe mode
 Public doingTrade() As Boolean
 Public doingTrade2() As Boolean
 Public lastPing() As Long
+Public XYZCountdowns() As TypeMatrixPosition
 Public SendToServer() As Byte
 Public AfterLoginLogoutReason() As String
 Public pushTarget() As Double
@@ -3018,7 +3019,12 @@ Public Function LearnFromPacket(ByRef packet() As Byte, pos As Long, idConnectio
       End If
 
       tileID = GetTheLong(packet(pos), packet(pos + 1))
-      
+      If (tileID = 2129) Then ' 2129 = magic wall
+       frmHardcoreCheats.AddXYZCounter idConnection, initX, initY, initZ, 20
+      ElseIf (tileID = 2130) Then ' 2130 = wild growth
+       frmHardcoreCheats.AddXYZCounter idConnection, initX, initY, initZ, 45
+      End If
+
 
          
       Select Case tileID


### PR DESCRIPTION
when "Show color effects" is active in Hardcore Cheats, this code will animate the number of seconds left of a magic wall / wild growth before it disappears, on the wall itself. personally, this would have saved me A LOT of deaths in the past..

![cool](https://cloud.githubusercontent.com/assets/1874996/12672338/d37b478c-c675-11e5-93eb-d2b188adf7f2.jpg)

this code has at least 1 issue, it can only count MAXCLIENTS walls per character, i guess we'll have to do some "ReDim Preserve" stuff to keep count of more walls than MAXCLIENTS, also, it is UNTESTED in RL tibia, i just tested it in 7.6, but i don't think the protocol has changed since then, where the protocol is
 84  XX XX YY YY ZZ COLOR(1 byte) tibiastr 
and warning, some colors will make the client crash, so make sure you use a real color, not 0x00 (i chose 66 as the color, a green color)
