### PR TITLE
fix the mwall / wild growth counter in 1090 / RL tibia

### DIFF
--- a/frmHardcoreCheats.frm
+++ b/frmHardcoreCheats.frm
@@ -1113,10 +1113,29 @@ CurrTicks = GetTickCount()
 '        Debug.Print XYZCountdowns(i, ii).z
 '        Debug.Print XYZCountdowns(i, ii).s
 '         Debug.Print SecondsLeft
+            If (TibiaVersionLong >= 1090) Then
+           'This Protocol is confirmed for: 1090->1090
+           'Todo: check older versions
+           'recieved packet:
+           'AA 00 00 00 00 07 00 42 72 61 64 77 65 6E 20 00 24 1A 82 D3 7B 07 06 00 4D 75 6E 63 68 2E 6B 19 82 D3 7B 07 01 F9 0D FF 04
+           'shrinking packet, removing useless ??? info:
+           'AA 00 00 00 00 00 00  20 00 24 1A 82 D3 7B 07 06 00 4D 75 6E 63 68 2E 6B 19 82 D3 7B 07 01 F9 0D FF 04
+           ' building custom packet:
+           'AA 00 00 00 00 00 00 20 00 24 $numbertohex2:{$myx$}$ $numbertohex2:{$myy$}$ $numbertohex1:{$myz$}$ $hex-tibiastr:the quick brown fox$
+           modCode.sendString i, "AA 00 00 00 00 00 00 20 00 24 " & FiveChrLon(XYZCountdowns(i, ii).X) & " " & FiveChrLon(XYZCountdowns(i, ii).y) & " " & GoodHex(CByte(XYZCountdowns(i, ii).z)) & " " & Hexarize2(CStr(SecondsLeft)), False, True
+            Else
+           'This protocol is confirmed for: 760->760
+           'Todo: check newer versions.
 'exiva < 84 7F 04 D2 01 07 66 05 00 31 30 30 30 30
 '        ^t XX XX YY YY ZZ CO TibiaStr
 '         modCode.sendString i, "84 7F 04 D2 01 07 66 05 00 31 30 30 30 30", False, True
+' Dim str As String
+ ' str = "84 " & FiveChrLon(XYZCountdowns(i, ii).X) & " " & FiveChrLon(XYZCountdowns(i, ii).y) & " " & GoodHex(CByte(XYZCountdowns(i, ii).z)) & " 66 " & Hexarize2(CStr(SecondsLeft))
+'Debug.Print str
          modCode.sendString i, "84 " & FiveChrLon(XYZCountdowns(i, ii).X) & " " & FiveChrLon(XYZCountdowns(i, ii).y) & " " & GoodHex(CByte(XYZCountdowns(i, ii).z)) & " 66 " & Hexarize2(CStr(SecondsLeft)), False, True
+          End If
+
+
          End If
       End If
     Next

--- a/modMap.bas
+++ b/modMap.bas
@@ -3019,7 +3019,7 @@ Public Function LearnFromPacket(ByRef packet() As Byte, pos As Long, idConnectio
       End If
 
       tileID = GetTheLong(packet(pos), packet(pos + 1))
-      If (tileID = 2129) Then ' 2129 = magic wall
+      If (tileID = 2129 Or tileID = 2128) Then 'magic wall. 2129 in 760, 2128 in 1090
        frmHardcoreCheats.AddXYZCounter idConnection, initX, initY, initZ, 20
       ElseIf (tileID = 2130) Then ' 2130 = wild growth
        frmHardcoreCheats.AddXYZCounter idConnection, initX, initY, initZ, 45


### PR DESCRIPTION
a few things has changed from 760 days, the ID of magic wall changed to 2128 ,  and the protocol changed a bit for animating text.   i have made a fix for RL tibia / 1090, but should still look at all the clients between 7.6 and 10.90, there's a lot of them :(
![rltibia](https://cloud.githubusercontent.com/assets/1874996/12759758/46428a94-c9e3-11e5-870c-3263a64b8a37.png)
the picture you see above is from RL tibia.
