### PR TITLE
support sub-second WaitX (WaitX 0.1)

### DIFF
--- a/modCavebot.bas
+++ b/modCavebot.bas
@@ -1884,9 +1884,10 @@ fastSet:
     DoEvents
   Case "waitx"
     param1 = ParseString(currLine, pos, lenCurrLine, ",")
-    val1 = CLng(param1)
-    waitCounter(Sid) = GetTickCount() + (val1 * 1000)
-   ' exeLine(Sid) = exeLine(Sid) + 1
+    ' val1 = CLng(param1)
+    ' waitCounter(Sid) = GetTickCount() + (val1 * 1000)
+    ' CDbl() use comma, not dot, but we use dot, not comma, so...
+    waitCounter(Sid) = GetTickCount() + CLng(CDbl(Replace(param1, ".", ",")) * 1000)
     updateExeLine Sid, 1, True
   Case "closeconnection"
     frmMain.txtPackets.Text = frmMain.txtPackets.Text & vbCrLf & "#Client " & Sid & " (" & CharacterName(Sid) & ")closed by script#"


### PR DESCRIPTION
the WaitX cavebot command can now be used to wait sub-second amounts of time,

for example to wait 0.1 second (AKA 100 milliseconds) use: WaitX 0.1

to sleep for 500 milliseconds, use WaitX 0.5

existing codes using "WaitX 1" and so on, are unaffected. 

- i didn't add it to the changelog yet because updating the changelog here would cause git merge conflict with PR #100 , i think (which is not (yet?) accepted)