### PR TITLE
fix off-by-one in doTurbo

### DIFF
--- a/modCode.bas
+++ b/modCode.bas
@@ -8738,7 +8738,7 @@ Public Function TranslateDirectionByteToHumanLang(directionID As Byte) As String
     TranslateDirectionByteToHumanLang = res
 End Function
 Public Function DoTurbo(idConnection As Integer) As Long
-  Dim cPacket(3) As Byte
+  Dim cPacket(2) As Byte
   Dim curDirPlayer As Byte
   #If FinalMode Then
   On Error GoTo goterr


### PR DESCRIPTION
cPacket(3) tried to send "01 00 65 00" instead of "01 00 65", which has an invalid size header, which would immediately break the connection (due to the invalid packet size header)

The result was that "exiva turbo" functioned like "exiva close" ...

>In Visual Basic 6, when you declare an array using Dim cPacket(3) As Byte, you're creating an array of Byte data type with 4 elements. This is because Visual Basic 6 arrays are zero-based, so the array cPacket(3) has elements indexed from 0 to 3.